### PR TITLE
cheerio-req 2.0.0

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -9,9 +9,9 @@ You can change the `request` function by overriding the `request` field.
 
 #### Params
 
-- **Object|String** `opts`: The request url or an object passed to [`tinyrequest`](https://github.com/IonicaBizau/tinyreq).
+- **Object|String** `opts`: The request url or an object passed to [`axios`](https://github.com/axios/axios).
 - **Function** `cb`: The callback function.
 
 #### Return
-- **Request** The [`tinyrequest`](https://github.com/IonicaBizau/tinyreq) object.
+- **Promise** The [`axios`](https://github.com/axios/axios) resolving with the data.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-20 Ionică Bizău <bizauionica@gmail.com> (https://ionicabizau.net)
+Copyright (c) 2016-23 Ionică Bizău <bizauionica@gmail.com> (https://ionicabizau.net)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ yarn add cheerio-req
 ```js
 const cheerioReq = require("cheerio-req");
 
-cheerioReq("http://ionicabizau.net", (err, $) => {
+(async () => {
+    const { $ } = await cheerioReq("http://ionicabizau.net")
     let $links = $("a.article-title");
     for (let i = 0; i < $links.length; ++i) {
         console.log($links.eq(i).text());
@@ -85,7 +86,7 @@ cheerioReq("http://ionicabizau.net", (err, $) => {
     // Pi Day, Raspberry Pi and Command Line
     // How I ported Memory Blocks to modern web
     // How to convert JSON to Markdown using json2md
-});
+})()
 ```
 
 
@@ -122,11 +123,11 @@ You can change the `request` function by overriding the `request` field.
 
 #### Params
 
-- **Object|String** `opts`: The request url or an object passed to [`tinyrequest`](https://github.com/IonicaBizau/tinyreq).
+- **Object|String** `opts`: The request url or an object passed to [`axios`](https://github.com/axios/axios).
 - **Function** `cb`: The callback function.
 
 #### Return
-- **Request** The [`tinyrequest`](https://github.com/IonicaBizau/tinyreq) object.
+- **Promise** The [`axios`](https://github.com/axios/axios) resolving with the data.
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cheerio-req",
-  "version": "1.2.4",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cheerio-req",
-      "version": "1.2.4",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "object"
   ],
   "license": "MIT",
-  "version": "1.2.4",
+  "version": "2.0.0",
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "menu/",
     "cli.js",
     "index.js",
+    "index.d.ts",
+    "package-lock.json",
     "bloggify.js",
     "bloggify.json",
     "bloggify/"


### PR DESCRIPTION
## 2.0.0

Breaking changes:
 - Remove the callback interface. Use async-await.
 - Use axios instead of tinyreq.
 - Perhaps does not support older versions of node (?).

Rewrite the codebase and simplify it.